### PR TITLE
Fix "Poplar Plains" missing bug in location search

### DIFF
--- a/scripts/airflow/tasks/location_search_index/transform_intersections_index.sql
+++ b/scripts/airflow/tasks/location_search_index/transform_intersections_index.sql
@@ -7,7 +7,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS location_search.centreline_intersection A
     MIN(elevatio9) AS elevatio9
   FROM gis.centreline_intersection
   WHERE
-    intersec5 IS NOT NULL AND intersec5 LIKE '%/%' AND intersec5 NOT LIKE '% Pl%'
+    intersec5 IS NOT NULL AND intersec5 LIKE '%/%'
     AND elevatio9 != 0 AND elevatio9 < 501700
   GROUP BY int_id
 );


### PR DESCRIPTION
# Issue Addressed
This PR addresses [`bdit_flashcrow` issue 654](https://github.com/CityofToronto/bdit_flashcrow/issues/654).

# Description
We remove an unnecessary `NOT LIKE '% Pl%'` condition from the `location_search.centreline_intersection` index.

# Tests
Updated ETL job, dropped matview in dev, re-ran ETL job, tested that "Poplar Plains" is searchable in MOVE dev, tested that other searches still work.

Will also update dev dataset in local development.
