### PR TITLE
Add midblock location naming view

### DIFF
--- a/scripts/airflow/dags/location_search_index.py
+++ b/scripts/airflow/dags/location_search_index.py
@@ -14,4 +14,5 @@ SCHEDULE_INTERVAL = '30 6 * * 6'
 DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
 
 TRANSFORM_INTERSECTIONS_INDEX = create_bash_task_nested(DAG, 'transform_intersections_index')
+TRANSFORM_MIDBLOCKS_INDEX = create_bash_task_nested(DAG, 'transform_midblocks_index')
 TRANSFORM_TRAFFIC_SIGNAL = create_bash_task_nested(DAG, 'transform_traffic_signal')

--- a/scripts/airflow/tasks/dev_data/dump_dev_data.sh
+++ b/scripts/airflow/tasks/dev_data/dump_dev_data.sh
@@ -161,6 +161,8 @@ mkdir -p /data/dev_data
   #
 
   # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t location_search.centreline -x --no-owner --clean --if-exists --schema-only
+  # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t location_search.centreline_intersection -x --no-owner --clean --if-exists --schema-only
   # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t location_search.traffic_signal -x --no-owner --clean --if-exists --schema-only
@@ -175,6 +177,7 @@ mkdir -p /data/dev_data
   # refresh data for view definitions
   #
 
+  echo 'REFRESH MATERIALIZED VIEW location_search.centreline;'
   echo 'REFRESH MATERIALIZED VIEW location_search.centreline_intersection;'
   echo 'REFRESH MATERIALIZED VIEW location_search.traffic_signal;'
 

--- a/scripts/airflow/tasks/location_search_index/transform_midblocks_index.sh
+++ b/scripts/airflow/tasks/location_search_index/transform_midblocks_index.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/location_search_index/transform_midblocks_index.sql"

--- a/scripts/airflow/tasks/location_search_index/transform_midblocks_index.sql
+++ b/scripts/airflow/tasks/location_search_index/transform_midblocks_index.sql
@@ -1,0 +1,19 @@
+CREATE SCHEMA IF NOT EXISTS location_search;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS location_search.centreline AS (
+  SELECT
+    gc.geo_id,
+    MODE() WITHIN GROUP (ORDER BY gc.lf_name) AS "midblockName",
+    MODE() WITHIN GROUP (ORDER BY fgci.intersec5) AS "fromIntersectionName",
+    MODE() WITHIN GROUP (ORDER BY tgci.intersec5) AS "toIntersectionName"
+  FROM gis.centreline gc
+  LEFT JOIN gis.centreline_intersection fgci ON gc.fnode = fgci.int_id
+  LEFT JOIN gis.centreline_intersection tgci ON gc.tnode = tgci.int_id
+  WHERE gc.fcode >= 201200 AND gc.fcode <= 201800
+  AND fgci.elevatio9 >= 501200 AND fgci.elevatio9 <= 501700
+  GROUP BY gc.geo_id
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ls_centreline_geo_id ON location_search.centreline (geo_id);
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY location_search.centreline;


### PR DESCRIPTION
# Issue Addressed
This PR addresses part of [`bdit_flashcrow` issue 539](https://github.com/CityofToronto/bdit_flashcrow/issues/539).

# Description
Adds `location_search.centreline` as part of the `location_search_index` DAG.  Note that we don't actually offer the ability to search by midblocks yet - that would require extensive thought around how to present those results alongside intersections.

# Tests
Tested that DAG runs properly and creates view / index.  Tested that `dev_data` DAG still runs, and that we can use it in local development along with `web` changes to show rich descriptions for midblocks.