### PR TITLE
Wrap replicator-transfer.sh in Airflow DAG

### DIFF
--- a/scripts/airflow/dags/airflow_utils.py
+++ b/scripts/airflow/dags/airflow_utils.py
@@ -11,11 +11,15 @@ import sys
 
 from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
+import pendulum
 
 AIRFLOW_DAGS = os.path.dirname(os.path.realpath(__file__))
 AIRFLOW_ROOT = os.path.dirname(AIRFLOW_DAGS)
 AIRFLOW_TASKS = os.path.join(AIRFLOW_ROOT, 'tasks')
 AIRFLOW_TASKS_LIB = os.path.join(AIRFLOW_TASKS, 'lib')
+
+# Toronto timezone - important to make sure cron schedules are in the right timezone!
+LOCAL_TZ = pendulum.timezone('America/Toronto')
 
 # Some tasks rely on Python libraries within the `tasks/lib` folder, so
 # we add that to the path here.
@@ -37,6 +41,7 @@ def create_dag(filepath, doc, start_date, schedule_interval):
   This function imposes the convention that a DAG file with name
   `my_dag.py` has ID `my_dag`.
   """
+  start_date_local = LOCAL_TZ.convert(start_date)
   default_args = {
     # When on, `depends_on_past` freezes progress if a previous run failed.
     # This isn't ideal for our use case, so we disable it here.
@@ -45,7 +50,7 @@ def create_dag(filepath, doc, start_date, schedule_interval):
     'email_on_failure': True,
     'email_on_retry': True,
     'owner': 'ec2-user',
-    'start_date': start_date
+    'start_date': start_date_local
   }
 
   # Auto-infer DAG ID from filename.

--- a/scripts/airflow/dags/conflate_artery_centreline.py
+++ b/scripts/airflow/dags/conflate_artery_centreline.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from airflow_utils import create_dag, create_bash_task_nested
 
 START_DATE = datetime(2020, 5, 5)
-SCHEDULE_INTERVAL = '30 4 * * *'
+SCHEDULE_INTERVAL = '0 7 * * 6'
 DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
 
 A1_CENTRELINE_FILTERED = create_bash_task_nested(DAG, 'A1_centreline_filtered')

--- a/scripts/airflow/dags/crash_geocoding.py
+++ b/scripts/airflow/dags/crash_geocoding.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from airflow_utils import create_dag, create_bash_task_nested
 
 START_DATE = datetime(2019, 7, 17)
-SCHEDULE_INTERVAL = '10 6-22 * * 1-5'
+SCHEDULE_INTERVAL = '20 19 * * 1-5'
 DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
 
 A1_EVENTS_FIELDS_RAW = create_bash_task_nested(DAG, 'A1_events_fields_raw')

--- a/scripts/airflow/dags/group_multiday_counts.py
+++ b/scripts/airflow/dags/group_multiday_counts.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from airflow_utils import create_dag, create_bash_task_nested
 
 START_DATE = datetime(2020, 3, 1)
-SCHEDULE_INTERVAL = '30 5 * * *'
+SCHEDULE_INTERVAL = '0 8 * * 6'
 DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
 
 A1_COUNTS_MULTIDAY_RUNS = create_bash_task_nested(DAG, 'A1_counts_multiday_runs')

--- a/scripts/airflow/dags/group_multidirection_arteries.py
+++ b/scripts/airflow/dags/group_multidirection_arteries.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from airflow_utils import create_dag, create_bash_task_nested
 
 START_DATE = datetime(2020, 5, 6)
-SCHEDULE_INTERVAL = '0 5 * * *'
+SCHEDULE_INTERVAL = '30 7 * * 6'
 DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
 
 A2_ARTERIES_MIDBLOCK_LINK_PAIRS = create_bash_task_nested(DAG, 'A2_arteries_midblock_link_pairs')

--- a/scripts/airflow/dags/replicator_transfer_crash.py
+++ b/scripts/airflow/dags/replicator_transfer_crash.py
@@ -1,0 +1,22 @@
+"""
+replicator_transfer_crash
+
+Complete replication of CRASH data by loading it from `/data/replicator/flashcrow-CRASH`
+into the database.
+"""
+# pylint: disable=pointless-statement
+from datetime import datetime
+
+from airflow.operators.bash_operator import BashOperator
+
+from airflow_utils import create_dag
+
+START_DATE = datetime(2020, 10, 15)
+SCHEDULE_INTERVAL = '10 19 * * 1-5'
+DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
+
+REPLICATOR_TRANSFER_CRASH = BashOperator(
+  task_id='replicator_transfer_crash',
+  bash_command='/replicator_transfer/replicator-transfer-CRASH.sh',
+  dag=DAG
+)

--- a/scripts/airflow/dags/replicator_transfer_flow.py
+++ b/scripts/airflow/dags/replicator_transfer_flow.py
@@ -1,0 +1,22 @@
+"""
+replicator_transfer_flow
+
+Complete replication of FLOW data by loading it from `/data/replicator/flashcrow-FLOW`
+into the database.
+"""
+# pylint: disable=pointless-statement
+from datetime import datetime
+
+from airflow.operators.bash_operator import BashOperator
+
+from airflow_utils import create_bash_task_nested, create_dag
+
+START_DATE = datetime(2020, 10, 15)
+SCHEDULE_INTERVAL = '30 3 * * 6'
+DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
+
+REPLICATOR_TRANSFER_FLOW = BashOperator(
+  task_id='replicator_transfer_flow',
+  bash_command='/replicator_transfer/replicator-transfer-FLOW.sh',
+  dag=DAG
+)

--- a/scripts/airflow/tasks/replicator_transfer/replicator-transfer-CRASH.sh
+++ b/scripts/airflow/tasks/replicator_transfer/replicator-transfer-CRASH.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+"${TASKS_ROOT}/replicator_transfer/replicator-transfer.sh" --chunkSize 1000000 --config "CRASH" --emailsTo "move-ops@toronto.ca" --rowCountTolerance 0.05 --targetSchema "TRAFFIC" --targetValidationSchema "TRAFFIC_NEW"

--- a/scripts/airflow/tasks/replicator_transfer/replicator-transfer-FLOW.sh
+++ b/scripts/airflow/tasks/replicator_transfer/replicator-transfer-FLOW.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+"${TASKS_ROOT}/replicator_transfer/replicator-transfer.sh" --chunkSize 2000000 --config "FLOW" --emailsTo "move-ops@toronto.ca" --rowCountTolerance 0.05 --targetSchema "TRAFFIC" --targetValidationSchema "TRAFFIC_NEW"

--- a/scripts/airflow/tasks/replicator_transfer/replicator-transfer.sh
+++ b/scripts/airflow/tasks/replicator_transfer/replicator-transfer.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+#
+# replicator-transfer.sh \
+#   --config CONFIG \
+#   --emailsTo EMAILS_TO \
+#   --rowCountTolerance ROW_COUNT_TOLERANCE \
+#   --targetSchema TARGET_SCHEMA \
+#   --targetValidationSchema TARGET_VALIDATION_SCHEMA
+#
+# Finishes the replication job with configuration profile $CONFIG,
+# using $TARGET_VALIDATION_SCHEMA in the database to validate before running
+# ALTER TABLE ... SET SCHEMA $TARGET_SCHEMA to quickly cut over to the new
+# data.  With this strategy, we can verify the data before it goes live, and
+# effective downtime is on the order of seconds even for the largest tables.
+#
+# For validation, we check that the final PostgreSQL row count is within a factor
+# of $ROW_COUNT_TOLERANCE of the original Oracle row count.  For instance,
+# $ROW_COUNT_TOLERANCE of 0.001 will expect no more than 0.1% deviation from the
+# original count.  This helps us verify that data arrived intact, while still
+# leaving some leeway for INSERT / DELETE queries that were executed against
+# Oracle during the migration.
+#
+# This is invoked on EC2 by replicator-local.ps1 via ssh, after that script has
+# built the data tarball and copied it over to EC2.
+#
+# Note that we have disabled SC2086 (double-quotes around arguments) in several
+# places, as we are intentionally expanding $PSQL_ARGS into separate arguments.
+
+set -e
+set -o nounset
+
+CHUNK_SIZE=
+CONFIG=
+declare -a EMAILS_TO
+ROW_COUNT_TOLERANCE=
+TARGET_SCHEMA=
+TARGET_VALIDATION_SCHEMA=
+
+function parse_args {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --chunkSize )
+      CHUNK_SIZE="$2"
+      shift
+      ;;
+      --config )
+      CONFIG="$2"
+      shift
+      ;;
+      --emailsTo )
+      EMAILS_TO+=("$2")
+      shift
+      ;;
+      --rowCountTolerance )
+      ROW_COUNT_TOLERANCE="$2"
+      shift
+      ;;
+      --targetSchema )
+      TARGET_SCHEMA="$2"
+      shift
+      ;;
+      --targetValidationSchema )
+      TARGET_VALIDATION_SCHEMA="$2"
+      shift
+      ;;
+      * )
+      echo "Invalid argument $1!"
+      exit 1
+      ;;
+    esac
+    shift
+  done
+
+  if [[ -z "$CHUNK_SIZE" ]]; then
+    echo "Chunk size required!"
+    exit 1
+  fi
+  if [[ -z "$CONFIG" ]]; then
+    echo "Config file required!"
+    exit 1
+  fi
+  if [[ -z "$ROW_COUNT_TOLERANCE" ]]; then
+    echo "Row count tolerance required!"
+    exit 1
+  fi
+  if [[ -z "$TARGET_SCHEMA" ]]; then
+    echo "Target schema required!"
+    exit 1
+  fi
+  if [[ -z "$TARGET_VALIDATION_SCHEMA" ]]; then
+    echo "Target validation schema required!"
+    exit 1
+  fi
+}
+
+parse_args "$@"
+
+# paths to important folders / files
+DIR_ROOT="/data/replicator/flashcrow-$CONFIG"
+DIR_ORA_CNT="$DIR_ROOT/ora_cnt"
+DIR_PG="$DIR_ROOT/pg"
+DIR_DAT="$DIR_ROOT/dat"
+DIR_DAT_SPLIT="$DIR_ROOT/dat_split"
+CONFIG_FILE="/data/replicator/$CONFIG.config.json"
+
+# email settings
+EMAIL_FROM="Flashcrow Replicator <replicator@flashcrow-etl.intra.dev-toronto.ca>"
+EMAIL_SUBJECT_STATUS="[flashcrow] [replicator] Replication Status: $CONFIG"
+EMAIL_SUBJECT_ERROR="[flashcrow] [replicator] Replication Error: $CONFIG"
+EMAIL_SUBJECT_SUCCESS="[flashcrow] [replicator] Replication Success: $CONFIG"
+
+# squelch NOTICEs from psql
+export PGOPTIONS="--client-min-messages=warning"
+
+function sendStatus {
+  local -r MESSAGE="$1"
+  local -r NOW=$(TZ='America/Toronto' date +"%Y-%m-%dT%H:%M:%S")
+  for emailTo in "${EMAILS_TO[@]}"; do
+    echo "$MESSAGE" | mail -r "$EMAIL_FROM" -s "$EMAIL_SUBJECT_STATUS" "$emailTo"
+  done
+  echo "$NOW $MESSAGE"
+}
+
+function sendStatusEmailDisable {
+  local -r MESSAGE="$1"
+  local -r NOW=$(TZ='America/Toronto' date +"%Y-%m-%dT%H:%M:%S")
+  echo "$NOW $MESSAGE"
+}
+
+function exitError {
+  local -r MESSAGE="$1"
+  local -r NOW=$(TZ='America/Toronto' date +"%Y-%m-%dT%H:%M:%S")
+  for emailTo in "${EMAILS_TO[@]}"; do
+    echo "$MESSAGE" | mail -r "$EMAIL_FROM" -s "$EMAIL_SUBJECT_ERROR" "$emailTo"
+  done
+  (>&2 echo "$NOW $MESSAGE")
+  exit 1
+}
+
+function exitSuccess {
+  local -r MESSAGE="$1"
+  local -r NOW=$(TZ='America/Toronto' date +"%Y-%m-%dT%H:%M:%S")
+  for emailTo in "${EMAILS_TO[@]}"; do
+    echo "$MESSAGE" | mail -r "$EMAIL_FROM" -s "$EMAIL_SUBJECT_SUCCESS" "$emailTo"
+  done
+  echo "$NOW $MESSAGE"
+  exit 0
+}
+
+sendStatus "Starting remote PostgreSQL data transfer..."
+
+# unpack data files
+cd "$HOME"
+# shellcheck disable=SC2038
+find "$DIR_DAT" -name "*.gz" | xargs gunzip -f
+sendStatusEmailDisable "Unpacked data on transfer machine..."
+
+# split data files into chunks
+rm -rf "$DIR_DAT_SPLIT"
+mkdir -p "$DIR_DAT_SPLIT"
+# shellcheck disable=SC2086
+jq -r ".tables[].name" "$CONFIG_FILE" | while read -r table; do
+  DAT_FILE="$DIR_DAT/$table.dat"
+  DAT_SPLIT_PREFIX="$DIR_DAT_SPLIT/$table.dat."
+  split --verbose --numeric-suffixes --suffix-length=4 --lines="$CHUNK_SIZE" "$DAT_FILE" "$DAT_SPLIT_PREFIX"
+done
+sendStatusEmailDisable "Split data into chunks..."
+
+# run PostgreSQL schemas to create tables in validation schema
+# shellcheck disable=SC2086
+jq -r ".tables[].name" "$CONFIG_FILE" | while read -r table; do
+  PG_SQL_FILE="$DIR_PG/$table.sql"
+  env $(xargs < "$HOME/cot-env.config") psql -f "$PG_SQL_FILE"
+  if env $(xargs < "$HOME/cot-env.config") psql -tAc "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = '$TARGET_VALIDATION_SCHEMA' AND table_name = '$table')" | grep f; then
+    exitError "Failed to create table $TARGET_VALIDATION_SCHEMA.$table in remote PostgreSQL!"
+  fi
+  if env $(xargs < "$HOME/cot-env.config") psql -tAc "SELECT EXISTS (SELECT 1 FROM pg_matviews WHERE schemaname = '$TARGET_SCHEMA' AND matviewname = '$table')" | grep f; then
+    exitError "Failed to create materialized view $TARGET_SCHEMA.$table in remote PostgreSQL!"
+  fi
+done
+sendStatusEmailDisable "Created remote PostgreSQL validation tables and live materialized views..."
+
+# truncate validation schema tables
+# shellcheck disable=SC2086
+jq -r ".tables[].name" "$CONFIG_FILE" | while read -r table; do
+  env $(xargs < "$HOME/cot-env.config") psql -c "TRUNCATE TABLE \"$TARGET_VALIDATION_SCHEMA\".\"$table\" RESTART IDENTITY"
+  if env $(xargs < "$HOME/cot-env.config") psql -tAc "SELECT EXISTS (SELECT * FROM \"$TARGET_VALIDATION_SCHEMA\".\"$table\")" | grep t; then
+    exitError "Failed to truncate $TARGET_VALIDATION_SCHEMA.$table in remote PostgreSQL!"
+  fi
+done
+sendStatusEmailDisable "Truncated remote PostgreSQL validation tables..."
+
+# copy data from local text files to tables in validation schema
+# shellcheck disable=SC2086
+jq -r ".tables[].name" "$CONFIG_FILE" | while read -r table; do
+  # copy chunks
+  DAT_SPLIT_PREFIX="$DIR_DAT_SPLIT/$table.dat."
+  # shellcheck disable=SC2012
+  ls ${DAT_SPLIT_PREFIX}* | while read -r dat_split_file; do
+    env $(xargs < "$HOME/cot-env.config") psql -c "\COPY \"$TARGET_VALIDATION_SCHEMA\".\"$table\" FROM STDIN (FORMAT text, ENCODING 'UTF8')" < "$dat_split_file"
+    sendStatusEmailDisable "Copied $dat_split_file..."
+  done
+  sendStatusEmailDisable "Copied all splits for $TARGET_VALIDATION_SCHEMA.$table..."
+
+  # ensure that statistics exist using ANALYZE
+  env $(xargs < "$HOME/cot-env.config") psql -c "ANALYZE \"$TARGET_VALIDATION_SCHEMA\".\"$table\""
+
+  # check that row counts match within tolerance
+  PG_COUNT=$(env $(xargs < "$HOME/cot-env.config") psql -tAc "SELECT reltuples::BIGINT FROM pg_class JOIN pg_catalog.pg_namespace n ON n.oid = pg_class.relnamespace WHERE nspname = '$TARGET_VALIDATION_SCHEMA' AND relname = '$table'")
+  ORA_COUNT=$(cat "$DIR_ORA_CNT/$table.cnt")
+  BC_EXPR="($PG_COUNT - $ORA_COUNT) / $ORA_COUNT"
+  BC_EXPR="(-$ROW_COUNT_TOLERANCE < ($BC_EXPR)) && (($BC_EXPR) < $ROW_COUNT_TOLERANCE)"
+  ROW_COUNT_VALID=$(echo "$BC_EXPR" | bc)
+  if [ "$ROW_COUNT_VALID" = "0" ]; then
+    exitError "Row count mismatch on $TARGET_VALIDATION_SCHEMA.$table: Oracle ($ORA_COUNT rows) -> PostgreSQL ($PG_COUNT rows)!"
+  fi
+  sendStatusEmailDisable "Validated $TARGET_VALIDATION_SCHEMA.$table..."
+done
+sendStatusEmailDisable "Copied data into remote PostgreSQL validation schema..."
+
+# refresh materialized views in target schema
+# shellcheck disable=SC2086
+jq -r ".tables[].name" "$CONFIG_FILE" | while read -r table; do
+  env $(xargs < "$HOME/cot-env.config") psql -c "REFRESH MATERIALIZED VIEW CONCURRENTLY \"$TARGET_SCHEMA\".\"$table\""
+done
+sendStatusEmailDisable "Refreshed materialized views in remote PostgreSQL target schema..."
+exitSuccess "Finished remote PostgreSQL data transfer."


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on [`bdit_flashcrow` issue 642](https://github.com/CityofToronto/bdit_flashcrow/issues/642).

# Description
We copy `replicator-transfer.sh` over from the private `bdit_move_scripts` repo (after verifying that it contains no private credentials!), and wrap it in a pair of Airflow DAGs: one for CRASH, one for FLOW.

In the process, we also update scheduling times for _all_ DAGs here to [use the `America/Toronto` timezone](http://airflow.apache.org/docs/stable/timezone.html), so that we can properly coordinate timing here with `replicator-local.ps1` jobs on the `replicator` workstation.

# Tests
Tested individual task by running shell script directly, by running wrapper script with CLI args, and by running it via `airflow test`.  Tested DAG via the Airflow admin web interface.