### PR TITLE
Add DAG to generate Mapbox GL-compatible glyphs from open fonts

### DIFF
--- a/scripts/airflow/dags/font_glyphs.py
+++ b/scripts/airflow/dags/font_glyphs.py
@@ -1,0 +1,16 @@
+"""
+font_glyphs
+
+Generate signed-distance field font glyphs using the `openmaptiles/fonts` repo on GitHub.
+This allows us to serve our own fonts for use with Mapbox GL.
+"""
+# pylint: disable=pointless-statement
+from datetime import datetime
+
+from airflow_utils import create_dag, create_bash_task_nested
+
+START_DATE = datetime(2020, 10, 29)
+SCHEDULE_INTERVAL = '0 0 1 * *'
+DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
+
+FONT_GLYPHS = create_bash_task_nested(DAG, 'font_glyphs')

--- a/scripts/airflow/tasks/font_glyphs/font_glyphs.sh
+++ b/scripts/airflow/tasks/font_glyphs/font_glyphs.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 GIT_ROOT=/home/ec2-user/move_etl
 TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
 
+set +u
+# shellcheck disable=SC1090
+. "$HOME/.bashrc"
+set -u
+
 mkdir -p /data/fonts
 cd /data/fonts
 rm -rf fonts
@@ -12,6 +17,8 @@ git clone --depth=1 --branch=master https://github.com/openmaptiles/fonts.git
 cd fonts
 rm -rf .git
 rm -r metropolis noto-sans open-sans pt-sans
+echo "lts/*" > .nvmrc
+nvm use
 npm install
 node ./generate.js
 

--- a/scripts/airflow/tasks/font_glyphs/font_glyphs.sh
+++ b/scripts/airflow/tasks/font_glyphs/font_glyphs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+mkdir -p /data/fonts
+cd /data/fonts
+rm -rf fonts
+
+git clone --depth=1 --branch=master https://github.com/openmaptiles/fonts.git
+cd fonts
+rm -rf .git
+rm -r metropolis noto-sans open-sans pt-sans
+npm install
+node ./generate.js
+
+cp -r _output/. /data/glyphs

--- a/scripts/deployment/etl/nginx/default.d/glyphs.conf
+++ b/scripts/deployment/etl/nginx/default.d/glyphs.conf
@@ -1,5 +1,0 @@
-location /glyphs {
-    alias /data/glyphs;
-    autoindex on;
-    add_header Access-Control-Allow-Origin * always;
-}

--- a/scripts/deployment/etl/nginx/default.d/tiles.conf
+++ b/scripts/deployment/etl/nginx/default.d/tiles.conf
@@ -1,6 +1,0 @@
-location /tiles {
-    alias /data/tiles;
-    autoindex on;
-    add_header Access-Control-Allow-Origin * always;
-    add_header Content-Encoding gzip;
-}


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on [`bdit_flashcrow` issue 688](https://github.com/CityofToronto/bdit_flashcrow/issues/688).

# Description
We introduce `font_glyphs`, a DAG that uses the `openmaptiles/fonts` repo to generate Roboto glyphs for use in MOVE.

# Tests
Tested script separately.  Tested via Airflow admin console.
