### PR TITLE
Provide stable collision ID in ETL pipelines

### DIFF
--- a/scripts/airflow/tasks/collisions_vector_tiles/build_collisions_tiles.sh
+++ b/scripts/airflow/tasks/collisions_vector_tiles/build_collisions_tiles.sh
@@ -6,29 +6,11 @@ TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
 
 mkdir -p /data/tiles
 # shellcheck disable=SC2046
-env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v datesFromInterval="'1 year'" -f "${TASKS_ROOT}/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel3.sql" > /data/tiles/collisionsLevel3:1.json
-# shellcheck disable=SC2046
-env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v datesFromInterval="'3 year'" -f "${TASKS_ROOT}/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel3.sql" > /data/tiles/collisionsLevel3:3.json
-# shellcheck disable=SC2046
-env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v datesFromInterval="'5 year'" -f "${TASKS_ROOT}/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel3.sql" > /data/tiles/collisionsLevel3:5.json
-# shellcheck disable=SC2046
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v datesFromInterval="'10 year'" -f "${TASKS_ROOT}/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel3.sql" > /data/tiles/collisionsLevel3:10.json
 
 # shellcheck disable=SC2046
-env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v datesFromInterval="'1 year'" -f "${TASKS_ROOT}/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel2.sql" > /data/tiles/collisionsLevel2:1.json
-# shellcheck disable=SC2046
-env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v datesFromInterval="'3 year'" -f "${TASKS_ROOT}/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel2.sql" > /data/tiles/collisionsLevel2:3.json
-# shellcheck disable=SC2046
-env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v datesFromInterval="'5 year'" -f "${TASKS_ROOT}/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel2.sql" > /data/tiles/collisionsLevel2:5.json
-# shellcheck disable=SC2046
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v datesFromInterval="'10 year'" -f "${TASKS_ROOT}/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel2.sql" > /data/tiles/collisionsLevel2:10.json
 
-tippecanoe --progress-interval=10 --force -o /data/tiles/collisionsLevel3:1.mbtiles -l collisionsLevel3:1 -Z10 -z16 --accumulate-attribute=heatmap_weight:sum --cluster-densest-as-needed -r1 /data/tiles/collisionsLevel3:1.json
-tippecanoe --progress-interval=10 --force -o /data/tiles/collisionsLevel3:3.mbtiles -l collisionsLevel3:3 -Z10 -z16 --accumulate-attribute=heatmap_weight:sum --cluster-densest-as-needed -r1 /data/tiles/collisionsLevel3:3.json
-tippecanoe --progress-interval=10 --force -o /data/tiles/collisionsLevel3:5.mbtiles -l collisionsLevel3:5 -Z10 -z16 --accumulate-attribute=heatmap_weight:sum --cluster-densest-as-needed -r1 /data/tiles/collisionsLevel3:5.json
 tippecanoe --progress-interval=10 --force -o /data/tiles/collisionsLevel3:10.mbtiles -l collisionsLevel3:10 -Z10 -z16 --accumulate-attribute=heatmap_weight:sum --cluster-densest-as-needed -r1 /data/tiles/collisionsLevel3:10.json
 
-tippecanoe --progress-interval=10 --force -o /data/tiles/collisionsLevel2:1.mbtiles -l collisionsLevel2:1 -Z14 -z16 /data/tiles/collisionsLevel2:1.json
-tippecanoe --progress-interval=10 --force -o /data/tiles/collisionsLevel2:3.mbtiles -l collisionsLevel2:3 -Z14 -z16 /data/tiles/collisionsLevel2:3.json
-tippecanoe --progress-interval=10 --force -o /data/tiles/collisionsLevel2:5.mbtiles -l collisionsLevel2:5 -Z14 -z16 /data/tiles/collisionsLevel2:5.json
 tippecanoe --progress-interval=10 --force -o /data/tiles/collisionsLevel2:10.mbtiles -l collisionsLevel2:10 -Z14 -z16 /data/tiles/collisionsLevel2:10.json

--- a/scripts/airflow/tasks/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel2.sql
+++ b/scripts/airflow/tasks/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel2.sql
@@ -8,8 +8,10 @@ WITH event_injury AS (
 ),
 features AS (
   SELECT
-    ei.collision_id AS "id",
+    e.id,
     e.geom,
+    e.accdate,
+    ei.collision_id AS "collisionId",
     ei.injury
   FROM event_injury ei
   JOIN collisions.events e ON ei.collision_id = e.collision_id

--- a/scripts/airflow/tasks/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel3.sql
+++ b/scripts/airflow/tasks/collisions_vector_tiles/build_collisions_tiles/download_collisionsLevel3.sql
@@ -8,8 +8,9 @@ WITH event_injury AS (
 ),
 features AS (
   SELECT
-    ei.collision_id AS "id",
+    e.id,
     e.geom,
+    e.accdate,
     ei.injury,
     CASE
       WHEN ei.injury = 4 THEN 10

--- a/scripts/airflow/tasks/collisions_vector_tiles/extract_collisions_tiles.sh
+++ b/scripts/airflow/tasks/collisions_vector_tiles/extract_collisions_tiles.sh
@@ -2,20 +2,8 @@
 
 set -euo pipefail
 
-rm -rf /data/tiles/collisionsLevel3:1
-mb-util --image_format=pbf --silent /data/tiles/collisionsLevel3:1.mbtiles /data/tiles/collisionsLevel3:1
-rm -rf /data/tiles/collisionsLevel3:3
-mb-util --image_format=pbf --silent /data/tiles/collisionsLevel3:3.mbtiles /data/tiles/collisionsLevel3:3
-rm -rf /data/tiles/collisionsLevel3:5
-mb-util --image_format=pbf --silent /data/tiles/collisionsLevel3:5.mbtiles /data/tiles/collisionsLevel3:5
 rm -rf /data/tiles/collisionsLevel3:10
 mb-util --image_format=pbf --silent /data/tiles/collisionsLevel3:10.mbtiles /data/tiles/collisionsLevel3:10
 
-rm -rf /data/tiles/collisionsLevel2:1
-mb-util --image_format=pbf --silent /data/tiles/collisionsLevel2:1.mbtiles /data/tiles/collisionsLevel2:1
-rm -rf /data/tiles/collisionsLevel2:3
-mb-util --image_format=pbf --silent /data/tiles/collisionsLevel2:3.mbtiles /data/tiles/collisionsLevel2:3
-rm -rf /data/tiles/collisionsLevel2:5
-mb-util --image_format=pbf --silent /data/tiles/collisionsLevel2:5.mbtiles /data/tiles/collisionsLevel2:5
 rm -rf /data/tiles/collisionsLevel2:10
 mb-util --image_format=pbf --silent /data/tiles/collisionsLevel2:10.mbtiles /data/tiles/collisionsLevel2:10

--- a/scripts/airflow/tasks/crash_geocoding/A1_events_fields_raw.sql
+++ b/scripts/airflow/tasks/crash_geocoding/A1_events_fields_raw.sql
@@ -3,7 +3,8 @@ CREATE SCHEMA IF NOT EXISTS collisions;
 CREATE MATERIALIZED VIEW IF NOT EXISTS collisions.events_fields_raw AS (
   WITH collisions_events_geom AS (
     SELECT
-      row_number() OVER (ORDER BY "ACCDATE", "ACCNB") AS collision_id,
+      row_number() OVER (ORDER BY "ACCDATE", "ACCNB") AS id,
+      CONCAT(date_part('year', "ACCDATE"), ':', "ACCNB") AS collision_id,
       "ACCNB" AS accnb,
       "ACCDATE" AS accdate,
       --max("DAY_NO") AS day_no,

--- a/scripts/airflow/tasks/crash_geocoding/A2_events_fields_norm.sql
+++ b/scripts/airflow/tasks/crash_geocoding/A2_events_fields_norm.sql
@@ -2,6 +2,7 @@ CREATE SCHEMA IF NOT EXISTS collisions;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS collisions.events_fields_norm AS (
   SELECT
+    id,
     collision_id,
     accnb,
     accdate + format('%s hours %s minutes', acctime::int / 100, acctime::int % 100)::interval AS accdate,


### PR DESCRIPTION
# Issue Addressed
This PR addresses [`bdit_flashcrow` issue 725](https://github.com/CityofToronto/bdit_flashcrow/issues/725).

# Description
We change `collision_id` to a string in `${year}:${accnb}` format, to create a stable ID that can be used to identify collisions across zoom levels.  Since `tippecanoe` and `mapbox-gl` expect vector tiles to have integer IDs, we keep the old `row_number()`-based ID as `id` here.

We also remove the 1, 3, and 5-year datasets from collision vector tile generation, as the updated web codebase uses the 10-year with layer filters to handle these.

# Tests
Generated new dev dataset, used that to run tests with updated web codebase.  Manually tested changes in dev environment.
