### PR TITLE
New DAG: centreline conflation target

### DIFF
--- a/scripts/airflow/dags/centreline_conflation_target.py
+++ b/scripts/airflow/dags/centreline_conflation_target.py
@@ -1,0 +1,28 @@
+"""
+centreline_conflation_target
+
+Normalize the Toronto Centreline into common "conflation target" and "routing target"
+views, for use by other pipelines.
+"""
+# pylint: disable=pointless-statement
+from datetime import datetime
+
+from airflow_utils import create_dag, create_bash_task_nested
+
+START_DATE = datetime(2020, 12, 21)
+SCHEDULE_INTERVAL = '30 5 * * 6'
+DAG = create_dag(__file__, __doc__, START_DATE, SCHEDULE_INTERVAL)
+
+A1_INTERSECTION_IDS = create_bash_task_nested(DAG, 'A1_intersection_ids')
+A2_INTERSECTIONS = create_bash_task_nested(DAG, 'A2_intersections')
+A2_ROUTING_VERTICES = create_bash_task_nested(DAG, 'A2_routing_vertices')
+A3_MIDBLOCK_NAMES = create_bash_task_nested(DAG, 'A3_midblock_names')
+A4_MIDBLOCKS = create_bash_task_nested(DAG, 'A4_midblocks')
+A5_ROUTING_EDGES = create_bash_task_nested(DAG, 'A5_routing_edges')
+
+A1_INTERSECTION_IDS >> A2_INTERSECTIONS
+A1_INTERSECTION_IDS >> A2_ROUTING_VERTICES
+A2_INTERSECTIONS >> A3_MIDBLOCK_NAMES
+A3_MIDBLOCK_NAMES >> A4_MIDBLOCKS
+A2_ROUTING_VERTICES >> A5_ROUTING_EDGES
+A4_MIDBLOCKS >> A5_ROUTING_EDGES

--- a/scripts/airflow/tasks/centreline_conflation_target/A1_intersection_ids.sh
+++ b/scripts/airflow/tasks/centreline_conflation_target/A1_intersection_ids.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/centreline_conflation_target/A1_intersection_ids.sql"

--- a/scripts/airflow/tasks/centreline_conflation_target/A1_intersection_ids.sql
+++ b/scripts/airflow/tasks/centreline_conflation_target/A1_intersection_ids.sql
@@ -1,0 +1,19 @@
+CREATE SCHEMA IF NOT EXISTS centreline;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS centreline.intersection_ids AS (
+   WITH ids_raw AS (
+    SELECT fnode AS "int_id"
+    FROM gis.centreline gc
+    JOIN gis.centreline_intersection gci ON gc.fnode = gci.int_id
+    WHERE fcode <= 201803
+    UNION ALL
+    SELECT tnode AS "int_id"
+    FROM gis.centreline gc
+    JOIN gis.centreline_intersection gci ON gc.tnode = gci.int_id
+    WHERE fcode <= 201803
+  )
+  SELECT DISTINCT(int_id)
+  FROM ids_raw
+);
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY centreline.intersection_ids;

--- a/scripts/airflow/tasks/centreline_conflation_target/A1_intersection_ids.sql
+++ b/scripts/airflow/tasks/centreline_conflation_target/A1_intersection_ids.sql
@@ -15,5 +15,6 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS centreline.intersection_ids AS (
   SELECT DISTINCT(int_id)
   FROM ids_raw
 );
+CREATE UNIQUE INDEX IF NOT EXISTS centreline_intersection_ids_int_id ON centreline.intersection_ids (int_id);
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY centreline.intersection_ids;

--- a/scripts/airflow/tasks/centreline_conflation_target/A2_intersections.sh
+++ b/scripts/airflow/tasks/centreline_conflation_target/A2_intersections.sh
@@ -5,4 +5,4 @@ GIT_ROOT=/home/ec2-user/move_etl
 TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
 
 # shellcheck disable=SC2046
-env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/centreline_conflation_target/A1_intersection_ids.sql"
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/centreline_conflation_target/A2_intersections.sql"

--- a/scripts/airflow/tasks/centreline_conflation_target/A2_intersections.sh
+++ b/scripts/airflow/tasks/centreline_conflation_target/A2_intersections.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/centreline_conflation_target/A1_intersection_ids.sql"

--- a/scripts/airflow/tasks/centreline_conflation_target/A2_intersections.sql
+++ b/scripts/airflow/tasks/centreline_conflation_target/A2_intersections.sql
@@ -1,0 +1,21 @@
+CREATE SCHEMA IF NOT EXISTS centreline;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS centreline.intersections AS (
+  SELECT DISTINCT ON (gci.int_id)
+    gci.int_id::int AS "centrelineId",
+    2 AS "centrelineType",
+    gci.intersec5 AS "description",
+    gci.elevatio9 AS "featureCode",
+    gci.geom,
+    ST_Y(gci.geom) AS "lat",
+    ST_X(gci.geom) AS "lng"
+  FROM gis.centreline_intersection gci
+  JOIN centreline.intersection_ids USING (int_id)
+  WHERE gci.elevatio9 != 509200 OR gci.classifi6 != 'SEUML'
+);
+CREATE UNIQUE INDEX IF NOT EXISTS centreline_intersections_centreline ON centreline.intersections ("centrelineId");
+CREATE INDEX IF NOT EXISTS centreline_intersections_geom ON centreline.intersections USING GIST (geom);
+CREATE INDEX IF NOT EXISTS centreline_intersections_srid3857_geom ON centreline.intersections USING GIST (ST_Transform(geom, 3857));
+CREATE INDEX IF NOT EXISTS centreline_intersections_srid2952_geom ON centreline.intersections USING GIST (ST_Transform(geom, 2952));
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY centreline.intersections;

--- a/scripts/airflow/tasks/centreline_conflation_target/A2_routing_vertices.sh
+++ b/scripts/airflow/tasks/centreline_conflation_target/A2_routing_vertices.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/centreline_conflation_target/A2_routing_vertices.sql"

--- a/scripts/airflow/tasks/centreline_conflation_target/A2_routing_vertices.sql
+++ b/scripts/airflow/tasks/centreline_conflation_target/A2_routing_vertices.sql
@@ -1,0 +1,12 @@
+CREATE SCHEMA IF NOT EXISTS centreline;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS centreline.routing_vertices AS (
+  SELECT DISTINCT ON (gci.int_id)
+    gci.int_id::int AS id,
+    ST_Transform(gci.geom, 2952) AS geom
+  FROM gis.centreline_intersection gci
+  JOIN centreline.intersection_ids USING (int_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS centreline_routing_vertices_id ON centreline.routing_vertices (id);
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY centreline.routing_vertices;

--- a/scripts/airflow/tasks/centreline_conflation_target/A3_midblock_names.sh
+++ b/scripts/airflow/tasks/centreline_conflation_target/A3_midblock_names.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/centreline_conflation_target/A3_midblock_names.sql"

--- a/scripts/airflow/tasks/centreline_conflation_target/A3_midblock_names.sql
+++ b/scripts/airflow/tasks/centreline_conflation_target/A3_midblock_names.sql
@@ -1,0 +1,17 @@
+CREATE SCHEMA IF NOT EXISTS centreline;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS centreline.midblock_names AS (
+  SELECT
+    gc.geo_id,
+    MODE() WITHIN GROUP (ORDER BY gc.lf_name) AS "midblockName",
+    MODE() WITHIN GROUP (ORDER BY fci.description) AS "fromIntersectionName",
+    MODE() WITHIN GROUP (ORDER BY tci.description) AS "toIntersectionName"
+  FROM gis.centreline gc
+  LEFT JOIN centreline.intersections fci ON gc.fnode = fci."centrelineId"
+  LEFT JOIN centreline.intersections tci ON gc.tnode = tci."centrelineId"
+  WHERE gc.fcode <= 201803
+  GROUP BY gc.geo_id
+);
+CREATE UNIQUE INDEX IF NOT EXISTS centreline_midblock_names_geo_id ON centreline.midblock_names (geo_id);
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY centreline.midblock_names;

--- a/scripts/airflow/tasks/centreline_conflation_target/A4_midblocks.sh
+++ b/scripts/airflow/tasks/centreline_conflation_target/A4_midblocks.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/centreline_conflation_target/A4_midblocks.sql"

--- a/scripts/airflow/tasks/centreline_conflation_target/A4_midblocks.sql
+++ b/scripts/airflow/tasks/centreline_conflation_target/A4_midblocks.sql
@@ -1,0 +1,28 @@
+CREATE SCHEMA IF NOT EXISTS centreline;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS centreline.midblocks AS (
+  SELECT
+    va.aadt,
+    gc.geo_id::int AS "centrelineId",
+    1 AS "centrelineType",
+    gc.fcode AS "featureCode",
+    gc.fnode::int AS "fnode",
+    cmn."fromIntersectionName",
+    ST_LineMerge(gc.geom) AS "geom",
+    ST_Y(ST_ClosestPoint(gc.geom, ST_Centroid(gc.geom))) AS "lat",
+    ST_X(ST_ClosestPoint(gc.geom, ST_Centroid(gc.geom))) AS "lng",
+    gc.lf_name AS "midblockName",
+    gc.lfn_id AS "roadId",
+    gc.tnode::int AS "tnode",
+    cmn."toIntersectionName"
+  FROM gis.centreline gc
+  LEFT JOIN centreline.midblock_names cmn ON gc.geo_id = cmn.geo_id
+  LEFT JOIN volume.aadt va ON gc.geo_id = va.centreline_id
+  WHERE gc.fcode <= 201803
+);
+CREATE UNIQUE INDEX IF NOT EXISTS centreline_midblocks_centreline ON centreline.midblocks ("centrelineId");
+CREATE INDEX IF NOT EXISTS centreline_midblocks_geom ON centreline.midblocks USING GIST (geom);
+CREATE INDEX IF NOT EXISTS centreline_midblocks_srid3857_geom ON centreline.midblocks USING GIST (ST_Transform(geom, 3857));
+CREATE INDEX IF NOT EXISTS centreline_midblocks_srid2952_geom ON centreline.midblocks USING GIST (ST_Transform(geom, 2952));
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY centreline.midblocks;

--- a/scripts/airflow/tasks/centreline_conflation_target/A5_routing_edges.sh
+++ b/scripts/airflow/tasks/centreline_conflation_target/A5_routing_edges.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+GIT_ROOT=/home/ec2-user/move_etl
+TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
+
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/centreline_conflation_target/A5_routing_edges.sql"

--- a/scripts/airflow/tasks/centreline_conflation_target/A5_routing_edges.sql
+++ b/scripts/airflow/tasks/centreline_conflation_target/A5_routing_edges.sql
@@ -1,0 +1,22 @@
+CREATE SCHEMA IF NOT EXISTS centreline;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS centreline.routing_edges AS (
+  SELECT
+    cm."centrelineId" AS id,
+    cm.fnode AS source,
+    cm.tnode AS target,
+    ST_Length(ST_Transform(cm.geom, 2952)) AS cost,
+    -1 AS reverse_cost,
+    ST_X(vf.geom) AS x1,
+    ST_Y(vf.geom) AS y1,
+    ST_X(vt.geom) AS x2,
+    ST_Y(vt.geom) AS y2
+  FROM centreline.midblocks cm
+  JOIN centreline.routing_vertices vf ON cm.fnode = vf.id
+  JOIN centreline.routing_vertices vt ON cm.tnode = vt.id
+);
+CREATE UNIQUE INDEX IF NOT EXISTS centreline_routing_edges_id ON centreline.routing_edges (id);
+CREATE INDEX IF NOT EXISTS centreline_routing_edges_source ON centreline.routing_edges (source);
+CREATE INDEX IF NOT EXISTS centreline_routing_edges_target ON centreline.routing_edges (target);
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY centreline.routing_edges;

--- a/scripts/airflow/tasks/dev_data/create_schemas.sql
+++ b/scripts/airflow/tasks/dev_data/create_schemas.sql
@@ -1,15 +1,15 @@
+drop schema if exists centreline cascade;
 drop schema if exists collisions cascade;
 drop schema if exists counts cascade;
 drop schema if exists gis cascade;
 drop schema if exists location_search cascade;
-drop schema if exists routing cascade;
 drop schema if exists "TRAFFIC" cascade;
 drop schema if exists volume cascade;
 
+create schema centreline;
 create schema collisions;
 create schema counts;
 create schema gis;
 create schema location_search;
-create schema routing;
 create schema "TRAFFIC";
 create schema volume;

--- a/scripts/airflow/tasks/dev_data/dump_dev_data.sh
+++ b/scripts/airflow/tasks/dev_data/dump_dev_data.sh
@@ -161,28 +161,35 @@ mkdir -p /data/dev_data
   #
 
   # shellcheck disable=SC2046
-  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t location_search.centreline -x --no-owner --clean --if-exists --schema-only
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t centreline.intersection_ids -x --no-owner --clean --if-exists --schema-only
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t centreline.intersections -x --no-owner --clean --if-exists --schema-only
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t centreline.routing_vertices -x --no-owner --clean --if-exists --schema-only
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t centreline.midblock_names -x --no-owner --clean --if-exists --schema-only
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t centreline.midblocks -x --no-owner --clean --if-exists --schema-only
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t centreline.routing_edges -x --no-owner --clean --if-exists --schema-only
+
   # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t location_search.centreline_intersection -x --no-owner --clean --if-exists --schema-only
   # shellcheck disable=SC2046
   env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t location_search.traffic_signal -x --no-owner --clean --if-exists --schema-only
 
-  # shellcheck disable=SC2046
-  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t routing.centreline_vertices -x --no-owner --clean --if-exists --schema-only
-  # shellcheck disable=SC2046
-  env $(xargs < "/home/ec2-user/cot-env.config") pg_dump -t routing.centreline_edges -x --no-owner --clean --if-exists --schema-only
-
-
   #
   # refresh data for view definitions
   #
+  echo 'REFRESH MATERIALIZED VIEW centreline.intersection_ids;'
+  echo 'REFRESH MATERIALIZED VIEW centreline.intersections;'
+  echo 'REFRESH MATERIALIZED VIEW centreline.routing_vertices;'
+  echo 'REFRESH MATERIALIZED VIEW centreline.midblock_names;'
+  echo 'REFRESH MATERIALIZED VIEW centreline.midblocks;'
+  echo 'REFRESH MATERIALIZED VIEW centreline.routing_edges;'
 
-  echo 'REFRESH MATERIALIZED VIEW location_search.centreline;'
   echo 'REFRESH MATERIALIZED VIEW location_search.centreline_intersection;'
   echo 'REFRESH MATERIALIZED VIEW location_search.traffic_signal;'
-
-  echo 'REFRESH MATERIALIZED VIEW routing.centreline_vertices;'
-  echo 'REFRESH MATERIALIZED VIEW routing.centreline_edges;'
 } > "${FLASHCROW_DEV_DATA}"
 
 # compress to reduce copying bandwidth


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on [`bdit_flashcrow` issue 695](https://github.com/CityofToronto/bdit_flashcrow/issues/695).

# Description
We add the `centreline_conflation_target` job, which creates the new "conflation target": a normalized subset of the centreline for use throughout our data pipelines and application code.  We also update `dev_data` to take these new views into account.

Over the next few PRs, we'll gradually rebuild our conflation pipelines to use the conflation target, instead of separate one-off approaches as we have now - this should solve several reported inconsistencies and points of confusion.

This also provides a layer of indirection from the Toronto Centreline - which should help make this more reference-system-agnostic, if we ever need that (e.g. for open-source support / collaboration).

# Tests
Ran new DAG in AWS dev.  Ran `dev_data` in AWS dev, copied dev dataset over to local, ran MOVE, and tested briefly in browser.
