### PR TITLE
Add classification column to intersections

### DIFF
--- a/scripts/airflow/tasks/centreline_conflation_target/A2_intersections.sql
+++ b/scripts/airflow/tasks/centreline_conflation_target/A2_intersections.sql
@@ -4,6 +4,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS centreline.intersections AS (
   SELECT DISTINCT ON (gci.int_id)
     gci.int_id::int AS "centrelineId",
     2 AS "centrelineType",
+    gci.classifi6 AS "classification",
     gci.intersec5 AS "description",
     gci.elevatio9 AS "featureCode",
     gci.geom,


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on [`bdit_flashcrow` issue 695](https://github.com/CityofToronto/bdit_flashcrow/issues/695).

# Description
We add the new `classification` column to `centreline.intersections`, using values of `gis.centreline_intersection.classifi6`.

# Tests
Ran DAG, re-generated `dev_data`, copied dev dataset to local dev and ran MOVE.
