### PR TITLE
Add pseudo-vertices to routing index

### DIFF
--- a/scripts/airflow/tasks/centreline_conflation_target/A2_routing_vertices.sql
+++ b/scripts/airflow/tasks/centreline_conflation_target/A2_routing_vertices.sql
@@ -1,11 +1,38 @@
 CREATE SCHEMA IF NOT EXISTS centreline;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS centreline.routing_vertices AS (
+  WITH pseudo_vertex_ids AS (
+    SELECT DISTINCT ("centrelineId") FROM (
+      SELECT cm.fnode AS "centrelineId"
+      FROM centreline.midblocks cm
+      LEFT JOIN centreline.intersections_base cibf ON cm.fnode = cibf."centrelineId"
+      WHERE cibf."centrelineId" IS NULL
+      UNION ALL
+      SELECT cm.tnode AS "centrelineId"
+      FROM centreline.midblocks cm
+      LEFT JOIN centreline.intersections_base cibt ON cm.tnode = cibt."centrelineId"
+      WHERE cibt."centrelineId" IS NULL
+    ) t
+  ), pseudo_vertex_geom AS (
+    SELECT
+      pvi."centrelineId",
+      ST_Centroid(ST_Collect(cm.geom)) AS geom
+    FROM pseudo_vertex_ids pvi
+    JOIN LATERAL (
+      SELECT ST_Transform(geom, 2952) AS geom
+      FROM centreline.midblocks cm
+      WHERE cm.fnode = pvi."centrelineId" OR cm.tnode = pvi."centrelineId"
+    ) cm ON true
+    GROUP BY pvi."centrelineId"
+  )
   SELECT
     cib."centrelineId" AS id,
     ST_Transform(cib.geom, 2952) AS geom
   FROM centreline.intersections_base cib
   JOIN centreline.intersection_ids USING ("centrelineId")
+  UNION ALL
+  SELECT "centrelineId" AS id, geom
+  FROM pseudo_vertex_geom
 );
 CREATE UNIQUE INDEX IF NOT EXISTS centreline_routing_vertices_id ON centreline.routing_vertices (id);
 


### PR DESCRIPTION
# Issue Addressed
This PR makes progress on [`bdit_flashcrow` issue 755](https://github.com/CityofToronto/bdit_flashcrow/issues/755).

# Description
We fix issues near Mt. Pleasant Cemetery and High Park where centreline midblocks use `fnode` / `tnode` values that don't map to actual centreline intersections (!?) by adding those values into the routing index, with an estimate of their location.

Note that, since this is still just an estimated location, it is possible (but unlikely) that `pgr_astar` could misroute here.

# Tests
Updated routing index in AWS dev via `DROP MATERIALIZED VIEW centreline.routing_vertices CASCADE` and running the relevant task scripts again.  Tested that this allows us to route corridors in the two cases mentioned in the issue by routing them in AWS dev after updates.

Ran `centreline_conflation_target` DAG end-to-end.  Ran `dev_data` DAG end-to-end, copied data to local dev, and verified that it still loads correctly.
