### PR TITLE
Dump all resources to CSV, use tmcs_joined for decades

### DIFF
--- a/scripts/airflow/tasks/open_data_tmcs/A1_tmcs_count_metadata.sh
+++ b/scripts/airflow/tasks/open_data_tmcs/A1_tmcs_count_metadata.sh
@@ -6,3 +6,7 @@ TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
 
 # shellcheck disable=SC2046
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/open_data_tmcs/A1_tmcs_count_metadata.sql"
+
+mkdir -p /data/open_data/tmcs
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v "view=open_data.tmcs_count_metadata" -f "${TASKS_ROOT}/open_data_tmcs/download/download_view_as_csv.sql" > /data/open_data/tmcs/tmcs_count_metadata.csv

--- a/scripts/airflow/tasks/open_data_tmcs/A1_tmcs_count_metadata.sql
+++ b/scripts/airflow/tasks/open_data_tmcs/A1_tmcs_count_metadata.sql
@@ -1,7 +1,7 @@
 CREATE SCHEMA IF NOT EXISTS open_data;
 
 CREATE OR REPLACE VIEW open_data.tmcs_count_metadata AS (
-  SELECT
+  SELECT DISTINCT ON (cim."COUNT_INFO_ID")
     cim."COUNT_INFO_ID" AS count_id,
     cim."COUNT_DATE"::DATE AS count_date,
     cim."ARTERYCODE" AS location_id,

--- a/scripts/airflow/tasks/open_data_tmcs/A2_tmcs_locations.sh
+++ b/scripts/airflow/tasks/open_data_tmcs/A2_tmcs_locations.sh
@@ -6,3 +6,7 @@ TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
 
 # shellcheck disable=SC2046
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/open_data_tmcs/A2_tmcs_locations.sql"
+
+mkdir -p /data/open_data/tmcs
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v "view=open_data.tmcs_locations" -f "${TASKS_ROOT}/open_data_tmcs/download/download_view_as_csv.sql" > /data/open_data/tmcs/tmcs_locations.csv

--- a/scripts/airflow/tasks/open_data_tmcs/A4_tmcs_decades.sh
+++ b/scripts/airflow/tasks/open_data_tmcs/A4_tmcs_decades.sh
@@ -19,5 +19,7 @@ for YEAR_START in $(seq $DECADE_MIN 10 $DECADE_MAX); do
   YEAR_END=$(echo "$YEAR_START + 9" | bc)
   echo "$YEAR_START - $YEAR_END"
   DECADE_FILEPATH="/data/open_data/tmcs/tmcs_${YEAR_START}_${YEAR_END}.csv"
-  env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v "yearStart=${YEAR_START}" -v "yearEnd=${YEAR_END}" -f "${TASKS_ROOT}/open_data_tmcs/download_tmcs_decade.sql" > "$DECADE_FILEPATH"
+
+  # shellcheck disable=SC2046
+  env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v "yearStart=${YEAR_START}" -v "yearEnd=${YEAR_END}" -f "${TASKS_ROOT}/open_data_tmcs/download/download_tmcs_decade.sql" > "$DECADE_FILEPATH"
 done

--- a/scripts/airflow/tasks/open_data_tmcs/A4_tmcs_preview.sh
+++ b/scripts/airflow/tasks/open_data_tmcs/A4_tmcs_preview.sh
@@ -6,3 +6,7 @@ TASKS_ROOT="${GIT_ROOT}/scripts/airflow/tasks"
 
 # shellcheck disable=SC2046
 env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 < "${TASKS_ROOT}/open_data_tmcs/A4_tmcs_preview.sql"
+
+mkdir -p /data/open_data/tmcs
+# shellcheck disable=SC2046
+env $(xargs < "/home/ec2-user/cot-env.config") psql -v ON_ERROR_STOP=1 -v "view=open_data.tmcs_preview" -f "${TASKS_ROOT}/open_data_tmcs/download/download_view_as_csv.sql" > /data/open_data/tmcs/tmcs_preview.csv

--- a/scripts/airflow/tasks/open_data_tmcs/download/download_tmcs_decade.sql
+++ b/scripts/airflow/tasks/open_data_tmcs/download/download_tmcs_decade.sql
@@ -1,0 +1,6 @@
+COPY (
+  SELECT *
+  FROM open_data.tmcs_joined
+  WHERE date_part('year', count_date) >= :yearStart
+  AND date_part('year', count_date) <= :yearEnd
+) TO stdout WITH (FORMAT csv, HEADER true, ENCODING 'UTF-8');

--- a/scripts/airflow/tasks/open_data_tmcs/download/download_view_as_csv.sql
+++ b/scripts/airflow/tasks/open_data_tmcs/download/download_view_as_csv.sql
@@ -1,0 +1,4 @@
+COPY (
+  SELECT *
+  FROM :view
+) TO stdout WITH (FORMAT csv, HEADER true, ENCODING 'UTF-8');

--- a/scripts/airflow/tasks/open_data_tmcs/download_tmcs_decade.sql
+++ b/scripts/airflow/tasks/open_data_tmcs/download_tmcs_decade.sql
@@ -1,7 +1,0 @@
-COPY (
-  SELECT tcd.*
-  FROM open_data.tmcs_count_data tcd
-  JOIN open_data.tmcs_count_metadata tcm USING (count_id)
-  WHERE date_part('year', tcm.count_date) >= :yearStart
-  AND date_part('year', tcm.count_date) <= :yearEnd
-) TO stdout WITH (FORMAT csv, HEADER true, ENCODING 'UTF-8');


### PR DESCRIPTION
# Issue Addressed
This PR makes further progress on [`bdit_flashcrow` issue 787](https://github.com/CityofToronto/bdit_flashcrow/issues/787).

# Description
Getting this ready to go - we now have all resources dumped to CSV and available over HTTP, plus the per-decade dumps now include the full joined set of columns.

# Tests
Did some quick `COUNT(*) FROM ...`, `SELECT * FROM ... LIMIT 10` checks to make sure things look OK.  Checked our CSV dump folder, and also verified that these are available over HTTP.